### PR TITLE
Changing testnet referance

### DIFF
--- a/1.3.erc20-using-converter-en.md
+++ b/1.3.erc20-using-converter-en.md
@@ -9,6 +9,6 @@ has_children: true
 
 ## Using the ERC20 converter 
 
-Now that you have set up your Metamask account and received some testnet tokens, you can use the [ERC20 converter](http://kovan-bridge.singularitynet.io/) to migrate your ERC20 tokens to Cardano. 
+Now that you have set up your Metamask account and received some testnet tokens, you can use the [ERC20 converter](https://testnet.agix-converter.iohk.io/) to migrate your ERC20 tokens to Cardano. 
 
 In this section, we discuss the features of the ERC20 converter and ways of using it.


### PR DESCRIPTION
Changing the testnet reference from 'kovan-bridge.singularitynet.io' to 'testnet.agix-converter.iohk'